### PR TITLE
Update gcc version to gcc8

### DIFF
--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -7,10 +7,10 @@ class ArmElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -5,7 +5,7 @@ class ArmElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'

--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -7,10 +7,10 @@ class ArmElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -12,7 +12,7 @@ class ArmElfGcc < Formula
   depends_on 'arm-elf-binutils'
 
   def install
-    binutils = Formula.factory 'arm-elf-binutils'
+    binutils = Formulary.factory 'arm-elf-binutils'
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
     ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -14,10 +14,10 @@ class ArmElfGcc < Formula
   def install
     binutils = Formula.factory 'arm-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class ArmElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17f"
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -14,10 +14,10 @@ class ArmElfGcc < Formula
   def install
     binutils = Formulary.factory 'arm-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/arm-elf-gdb.rb
+++ b/arm-elf-gdb.rb
@@ -9,10 +9,10 @@ class ArmElfGdb < Formula
   depends_on 'arm-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=arm-elf-eabi', "--prefix=#{prefix}" ,'--disable-werror'

--- a/arm-elf-gdb.rb
+++ b/arm-elf-gdb.rb
@@ -9,10 +9,10 @@ class ArmElfGdb < Formula
   depends_on 'arm-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=arm-elf-eabi', "--prefix=#{prefix}" ,'--disable-werror'

--- a/i586-elf-binutils.rb
+++ b/i586-elf-binutils.rb
@@ -7,10 +7,10 @@ class I586ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/i586-elf-binutils.rb
+++ b/i586-elf-binutils.rb
@@ -7,10 +7,10 @@ class I586ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/i586-elf-binutils.rb
+++ b/i586-elf-binutils.rb
@@ -5,7 +5,7 @@ class I586ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -13,7 +13,7 @@ class I586ElfGcc < Formula
   depends_on 'i586-elf-binutils'
 
   def install
-    binutils = Formula.factory 'i586-elf-binutils'
+    binutils = Formulary.factory 'i586-elf-binutils'
 
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -16,10 +16,10 @@ class I586ElfGcc < Formula
     binutils = Formula.factory 'i586-elf-binutils'
 
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class I586ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17f"
 
   depends_on "gmp"
   depends_on "libmpc"

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -16,10 +16,10 @@ class I586ElfGcc < Formula
     binutils = Formulary.factory 'i586-elf-binutils'
 
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/i586-elf-gdb.rb
+++ b/i586-elf-gdb.rb
@@ -9,10 +9,10 @@ class I586ElfGdb < Formula
   depends_on 'i586-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=i586-elf', "--prefix=#{prefix}", "--disable-werror"

--- a/i586-elf-gdb.rb
+++ b/i586-elf-gdb.rb
@@ -9,10 +9,10 @@ class I586ElfGdb < Formula
   depends_on 'i586-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=i586-elf', "--prefix=#{prefix}", "--disable-werror"

--- a/x86_64-elf-binutils.rb
+++ b/x86_64-elf-binutils.rb
@@ -7,10 +7,10 @@ class X8664ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/x86_64-elf-binutils.rb
+++ b/x86_64-elf-binutils.rb
@@ -5,7 +5,7 @@ class X8664ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'

--- a/x86_64-elf-binutils.rb
+++ b/x86_64-elf-binutils.rb
@@ -7,10 +7,10 @@ class X8664ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -13,7 +13,7 @@ class X8664ElfGcc < Formula
   depends_on 'x86_64-elf-binutils'
 
   def install
-    binutils = Formula.factory 'x86_64-elf-binutils'
+    binutils = Formulary.factory 'x86_64-elf-binutils'
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
     ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class X8664ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17"
 
   depends_on "gmp"
   depends_on "libmpc"
@@ -15,10 +15,10 @@ class X8664ElfGcc < Formula
   def install
     binutils = Formula.factory 'x86_64-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -15,10 +15,10 @@ class X8664ElfGcc < Formula
   def install
     binutils = Formulary.factory 'x86_64-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/x86_64-elf-gdb.rb
+++ b/x86_64-elf-gdb.rb
@@ -9,10 +9,10 @@ class X8664ElfGdb < Formula
   depends_on 'x86_64-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=x86_64-pc-linux', "--prefix=#{prefix}"

--- a/x86_64-elf-gdb.rb
+++ b/x86_64-elf-gdb.rb
@@ -9,10 +9,10 @@ class X8664ElfGdb < Formula
   depends_on 'x86_64-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc@7/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc@7/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=x86_64-pc-linux', "--prefix=#{prefix}"


### PR DESCRIPTION
Gcc8 is now homebrews latest version - fixes build issues when running redox/bootstrap.sh